### PR TITLE
Adding a null() method wrapping the sqlite_bind_null(_,_) SQLite func

### DIFF
--- a/Sources/SQLite/SQLite.swift
+++ b/Sources/SQLite/SQLite.swift
@@ -230,6 +230,13 @@ extension SQLite {
         public func bind(_ value: Bool) throws {
             try bind(value ? 1 : 0)
         }
+        
+        //binds a null value, useful for inserting new rows without having to put an id
+        public func null()  throws {
+            if sqlite3_bind_null(pointer, nextBindPosition) != SQLITE_OK {
+                throw SQLiteError.bind(database.errorMessage)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Introduction
Adds a null() method to the SQLite module that binds a null value to a prepared statement.

# Motivation
This function is useful when the sqlite-driver for Fluent needs to insert a new row and the serializer generates a "INSERT INTO `` VALUES(?,?,?)". The first ? Needs to have either a correct id or a null value in order to auto increment.

# Code Snippet
### Creating a new post:
`let post = Post(id:nil, title:"Vapor is great", text:"Lorem ipsum etc.`
### Unwrapping a node in the sqlite-driver

```
func bind(statement: SQLite.Statement, to values: [Node]) throws  {
        for value in values {
            switch value {
            case .string(let string):
               try statement.bind(string)
            case .int(let number):
               try statement.bind(number)
            case .null:
                try statement.null()
         }
     }
}
```

# Impact
This solution only adds a new method so it wouldn't have much impact on existing code. If this proposal is accepted as is, I have another pull request ready that would update the sqlite driver with the new Node syntax plus a few tests

# Alternative considered
The syntax could be different like 
```func bind(null:true) throws``` or ```fund bindNull() throws```
The serializer could also serialize statements without an id placeholder that awaits a value. 
I chose this solution over the other ones because the C sqlite API provides this `sqlite_bind_null` function for those cases.

Thank you for getting interest in this proposal !



