### PR TITLE
Fix unicode string length not being interpreted right by SQLite

### DIFF
--- a/Sources/SQLite/SQLite.swift
+++ b/Sources/SQLite/SQLite.swift
@@ -221,7 +221,7 @@ extension SQLite {
         }
 
         public func bind(_ value: String) throws {
-            let strlen = Int32(value.characters.count)
+            let strlen = Int32(value.utf8CString.count)
             if sqlite3_bind_text(pointer, nextBindPosition, value, strlen, SQLITE_TRANSIENT) != SQLITE_OK {
                 throw SQLiteError.bind(database.errorMessage)
             }
@@ -231,7 +231,7 @@ extension SQLite {
             try bind(value ? 1 : 0)
         }
         
-        //binds a null value, useful for inserting new rows without having to put an id
+
         public func null()  throws {
             if sqlite3_bind_null(pointer, nextBindPosition) != SQLITE_OK {
                 throw SQLiteError.bind(database.errorMessage)

--- a/Tests/SQLiteTests/SQLite3Tests.swift
+++ b/Tests/SQLiteTests/SQLite3Tests.swift
@@ -2,11 +2,70 @@ import XCTest
 @testable import SQLite
 
 class SQLite3Tests: XCTestCase {
-    static let allTests = [
-       ("testReality", testReality)
-    ]
+    static let allTests = [""]
 
-    func testReality() {
-        XCTAssert(2 + 2 == 4, "Something is seriously wrong.")
+    var database:SQLite!
+    
+    override func setUp() {
+        self.database = SQLite.makeTestConnection()
     }
+    
+    func testTables() {
+        do {
+            try _ = database.execute("DROP TABLE IF EXISTS foo")
+            try _ = database.execute("CREATE TABLE foo (bar INT(4), baz VARCHAR(16))")
+            try _ = database.execute("INSERT INTO foo VALUES (42, 'Life')")
+            try _ = database.execute("INSERT INTO foo VALUES (1337, 'Elite')")
+            try _ = database.execute("INSERT INTO foo VALUES (9, NULL)")
+            
+            if let resultBar = try database.execute("SELECT * FROM foo WHERE bar = 42").first {
+                XCTAssertEqual(resultBar.data["bar"], "42")
+                XCTAssertEqual(resultBar.data["baz"], "Life")
+            } else {
+                XCTFail("Could not get bar result")
+            }
+            
+            
+            if let resultBaz = try database.execute("SELECT * FROM foo where baz = 'Elite'").first {
+                XCTAssertEqual(resultBaz.data["bar"], "1337")
+                XCTAssertEqual(resultBaz.data["baz"], "Elite")
+            } else {
+                XCTFail("Could not get baz result")
+            }
+            
+            if let resultBaz = try database.execute("SELECT * FROM foo where bar = 9").first {
+                XCTAssertEqual(resultBaz.data["bar"], "9")
+                XCTAssertEqual(resultBaz.data["baz"], nil)
+            } else {
+                XCTFail("Could not get null result")
+            }
+        } catch {
+            XCTFail("Testing tables failed: \(error)")
+        }
+    }
+    
+    func testUnicodeStrings() {
+        
+        do {
+            
+            /**
+                This string includes characters from most Unicode categories 
+                such as Latin, Latin-Extended-A/B, Cyrrilic, Greek etc.
+            */
+            let unicode = "®¿ÐØ×ĞƋƢǂǊǕǮȐȘȢȱȵẀˍΔῴЖ♆"
+            try _ = database.execute("DROP TABLE IF EXISTS `foo`")
+            try _ = database.execute("CREATE TABLE `foo` (bar TEXT)")
+            try _ = database.execute("INSERT INTO `foo` VALUES(?)") { statement in
+                try statement.bind(unicode)
+            }
+            
+            if let results = try database.execute("SELECT * FROM `foo`").first {
+                XCTAssertEqual(results.data["bar"], unicode)
+            }
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
+    }
+    
 }

--- a/Tests/SQLiteTests/SQLite3Tests.swift
+++ b/Tests/SQLiteTests/SQLite3Tests.swift
@@ -2,7 +2,8 @@ import XCTest
 @testable import SQLite
 
 class SQLite3Tests: XCTestCase {
-    static let allTests = [""]
+    static let allTests = ["testTables": testTables,
+                           "testUnicode": testUnicode]
 
     var database:SQLite!
     
@@ -44,7 +45,7 @@ class SQLite3Tests: XCTestCase {
         }
     }
     
-    func testUnicodeStrings() {
+    func testUnicode() {
         
         do {
             

--- a/Tests/SQLiteTests/SQLite3Tests.swift
+++ b/Tests/SQLiteTests/SQLite3Tests.swift
@@ -2,15 +2,15 @@ import XCTest
 @testable import SQLite
 
 class SQLite3Tests: XCTestCase {
-    static let allTests = ["testTables": testTables,
-                           "testUnicode": testUnicode]
+    static let allTests = [("testTables", testTables),
+                           ("testUnicode", testUnicode)]
 
     var database:SQLite!
-    
+
     override func setUp() {
         self.database = SQLite.makeTestConnection()
     }
-    
+
     func testTables() {
         do {
             try _ = database.execute("DROP TABLE IF EXISTS foo")
@@ -18,22 +18,22 @@ class SQLite3Tests: XCTestCase {
             try _ = database.execute("INSERT INTO foo VALUES (42, 'Life')")
             try _ = database.execute("INSERT INTO foo VALUES (1337, 'Elite')")
             try _ = database.execute("INSERT INTO foo VALUES (9, NULL)")
-            
+
             if let resultBar = try database.execute("SELECT * FROM foo WHERE bar = 42").first {
                 XCTAssertEqual(resultBar.data["bar"], "42")
                 XCTAssertEqual(resultBar.data["baz"], "Life")
             } else {
                 XCTFail("Could not get bar result")
             }
-            
-            
+
+
             if let resultBaz = try database.execute("SELECT * FROM foo where baz = 'Elite'").first {
                 XCTAssertEqual(resultBaz.data["bar"], "1337")
                 XCTAssertEqual(resultBaz.data["baz"], "Elite")
             } else {
                 XCTFail("Could not get baz result")
             }
-            
+
             if let resultBaz = try database.execute("SELECT * FROM foo where bar = 9").first {
                 XCTAssertEqual(resultBaz.data["bar"], "9")
                 XCTAssertEqual(resultBaz.data["baz"], nil)
@@ -44,13 +44,13 @@ class SQLite3Tests: XCTestCase {
             XCTFail("Testing tables failed: \(error)")
         }
     }
-    
+
     func testUnicode() {
-        
+
         do {
-            
+
             /**
-                This string includes characters from most Unicode categories 
+                This string includes characters from most Unicode categories
                 such as Latin, Latin-Extended-A/B, Cyrrilic, Greek etc.
             */
             let unicode = "®¿ÐØ×ĞƋƢǂǊǕǮȐȘȢȱȵẀˍΔῴЖ♆"
@@ -59,7 +59,7 @@ class SQLite3Tests: XCTestCase {
             try _ = database.execute("INSERT INTO `foo` VALUES(?)") { statement in
                 try statement.bind(unicode)
             }
-            
+
             if let results = try database.execute("SELECT * FROM `foo`").first {
                 XCTAssertEqual(results.data["bar"], unicode)
             }
@@ -68,5 +68,5 @@ class SQLite3Tests: XCTestCase {
         }
 
     }
-    
+
 }

--- a/Tests/SQLiteTests/Utilities.swift
+++ b/Tests/SQLiteTests/Utilities.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import SQLite
+
+extension SQLite {
+    static func makeTestConnection() -> SQLite? {
+        do {
+            let sqlite = try SQLite(path:"test_database.sqlite")
+            return sqlite
+            
+        } catch {
+            XCTFail()
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Hi, in reference to an issue mentioned on Slack, ( cc @harlanhaskins ) 
There's a fix that concerned SQLite not being able to insert strings properly when given the string length and not the number of scalars involved resulting in erratic characters being inserted.

In fact, SQLite does provide Unicode support by default however it needs to be provided with the number of scalars and not the number of actual characters in 
```swift
sqlite3_bind_text(pointer, nextBindPosition, value, strlen, SQLITE_TRANSIENT)
``` 

