### PR TITLE
Fixed correct utf8 length when binding string

### DIFF
--- a/Sources/SQLite/SQLite.swift
+++ b/Sources/SQLite/SQLite.swift
@@ -221,7 +221,7 @@ extension SQLite {
         }
 
         public func bind(_ value: String) throws {
-            let strlen = Int32(value.utf8CString.count)
+            let strlen = Int32(value.utf8.count)
             if sqlite3_bind_text(pointer, nextBindPosition, value, strlen, SQLITE_TRANSIENT) != SQLITE_OK {
                 throw SQLiteError.bind(database.errorMessage)
             }

--- a/Tests/SQLiteTests/SQLite3Tests.swift
+++ b/Tests/SQLiteTests/SQLite3Tests.swift
@@ -63,6 +63,17 @@ class SQLite3Tests: XCTestCase {
             if let results = try database.execute("SELECT * FROM `foo`").first {
                 XCTAssertEqual(results.data["bar"], unicode)
             }
+            else {
+                XCTFail("The query should return a result.")
+            }
+            
+            if let results = try database.execute("SELECT * FROM `foo` WHERE bar = '\(unicode)'").first {
+                XCTAssertEqual(results.data["bar"], unicode)
+            }
+            else {
+                XCTFail("The query should return a result.")
+            }
+            
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/SQLiteTests/SQLite3Tests.swift
+++ b/Tests/SQLiteTests/SQLite3Tests.swift
@@ -59,20 +59,14 @@ class SQLite3Tests: XCTestCase {
             try _ = database.execute("INSERT INTO `foo` VALUES(?)") { statement in
                 try statement.bind(unicode)
             }
-
-            if let results = try database.execute("SELECT * FROM `foo`").first {
-                XCTAssertEqual(results.data["bar"], unicode)
-            }
-            else {
-                XCTFail("The query should return a result.")
-            }
             
-            if let results = try database.execute("SELECT * FROM `foo` WHERE bar = '\(unicode)'").first {
-                XCTAssertEqual(results.data["bar"], unicode)
-            }
-            else {
-                XCTFail("The query should return a result.")
-            }
+            let selectAllResults = try database.execute("SELECT * FROM `foo`").first
+            XCTAssertNotNil(selectAllResults)
+            XCTAssertEqual(selectAllResults!.data["bar"], unicode)
+            
+            let selectWhereResults = try database.execute("SELECT * FROM `foo` WHERE bar = '\(unicode)'").first
+            XCTAssertNotNil(selectWhereResults)
+            XCTAssertEqual(selectWhereResults!.data["bar"], unicode)
             
         } catch {
             XCTFail(error.localizedDescription)


### PR DESCRIPTION
When binding a string, the string should not include the NULL termination for SQLite. This means that `utf8` rather than `utf8CString` should be used when determining the length of the data.