### PR TITLE
Add support for BLOB column type

### DIFF
--- a/Sources/SQLite/SQLite+Result.swift
+++ b/Sources/SQLite/SQLite+Result.swift
@@ -1,5 +1,6 @@
 import CSQLite
 import Node
+import typealias Core.Bytes
 
 extension SQLite {
     /**
@@ -42,6 +43,19 @@ extension SQLite {
                     }
                     
                     data[column] = .string(value)
+                    
+                case SQLITE_BLOB:
+                    if let blobPointer = sqlite3_column_blob(pointer, i) {
+                        let length = Int(sqlite3_column_bytes(pointer, i))
+                        
+                        let i8bufptr = UnsafeBufferPointer(start: blobPointer.assumingMemoryBound(to: Bytes.Element.self), count: length)
+                        
+                        data[column] = .bytes(Bytes(i8bufptr))
+                    } else {
+                        // The return value from sqlite3_column_blob() for a zero-length BLOB is a NULL pointer.
+                        // https://www.sqlite.org/c3ref/column_blob.html
+                        data[column] = .bytes([])
+                    }
                     
                 case SQLITE_INTEGER:
                     let integer = Int(sqlite3_column_int64(pointer, i))

--- a/Sources/SQLite/SQLite+Statement.swift
+++ b/Sources/SQLite/SQLite+Statement.swift
@@ -1,4 +1,5 @@
 import CSQLite
+import typealias Core.Bytes
 
 extension SQLite {
     /**
@@ -45,6 +46,13 @@ extension SQLite {
         public func bind(_ value: String) throws {
             let strlen = Int32(value.utf8.count)
             if sqlite3_bind_text(pointer, nextBindPosition, value, strlen, SQLITE_TRANSIENT) != SQLITE_OK {
+                throw SQLiteError.bind(database.errorMessage)
+            }
+        }
+        
+        public func bind(_ value: Bytes) throws {
+            let count = Int32(value.count)
+            if sqlite3_bind_blob(pointer, nextBindPosition, value, count, SQLITE_TRANSIENT) != SQLITE_OK {
                 throw SQLiteError.bind(database.errorMessage)
             }
         }

--- a/Tests/SQLiteTests/SQLite3Tests.swift
+++ b/Tests/SQLiteTests/SQLite3Tests.swift
@@ -87,6 +87,23 @@ class SQLite3Tests: XCTestCase {
             XCTAssertEqual(result.data["max"], max.makeNode(in: nil))
         }
     }
+    
+    
+    func testBlob() {
+        let data = Data(bytes: [0, 1, 2])
+        
+        _ = try! database.execute("DROP TABLE IF EXISTS `foo`")
+        _ = try! database.execute("CREATE TABLE foo (bar BLOB(4))")
+        _ = try! database.execute("INSERT INTO foo VALUES (?)") { statement in
+            try! statement.bind(data.makeBytes())
+        }
+        
+        if let result = try! database.execute("SELECT * FROM foo").first {
+            XCTAssertEqual(result.data["bar"], Node.bytes(data.makeBytes()))
+        } else {
+            XCTFail()
+        }
+    }
 
 
     static let allTests = [


### PR DESCRIPTION
I've noticed that storing bytes into sqlite database creates string instead of blob. Well and the biggest problem is that it will create string that looks like this "[120, 220, ...]".
This pull request is fixing this problem. It will now store the BLOB data correctly.

Part of the code was taken from SQLite.swift library, see https://github.com/stephencelis/SQLite.swift/blob/38ece82483475784b2d2377671e5367427992a72/Sources/SQLite/Core/Statement.swift