### PR TITLE
Fix empty array encoding crash

### DIFF
--- a/Sources/SQLite/Codable/SQLiteDataEncoder.swift
+++ b/Sources/SQLite/Codable/SQLiteDataEncoder.swift
@@ -24,7 +24,8 @@ public struct SQLiteDataEncoder {
             let encoder = _Encoder()
             do {
                 try value.encode(to: encoder)
-                return encoder.data!
+                guard let data = encoder.data else { throw _DoJSONError() }
+                return data
             } catch is _DoJSONError {
                 struct AnyEncodable: Encodable {
                     var encodable: Encodable

--- a/Tests/SQLiteTests/SQLiteTests.swift
+++ b/Tests/SQLiteTests/SQLiteTests.swift
@@ -158,6 +158,18 @@ class SQLiteTests: XCTestCase {
         group.wait()
     }
     
+    func testNonEmptyArrayEncodingDecoding() throws {
+        let nonEmptyArray = ["foo", "bar"]
+        let encoder = SQLiteDataEncoder()
+        
+        let data = try encoder.encode(nonEmptyArray)
+        
+        let decoder = SQLiteDataDecoder()
+        
+        let result = try decoder.decode([String].self, from: data)
+        XCTAssertEqual(result, nonEmptyArray, "Should convert back to original array")
+    }
+    
     func testEmptyArrayEncodingDecoding() throws {
         let emptyArray = [String]()
         let encoder = SQLiteDataEncoder()

--- a/Tests/SQLiteTests/SQLiteTests.swift
+++ b/Tests/SQLiteTests/SQLiteTests.swift
@@ -157,6 +157,18 @@ class SQLiteTests: XCTestCase {
         }
         group.wait()
     }
+    
+    func testEmptyArrayEncodingDecoding() throws {
+        let emptyArray = [String]()
+        let encoder = SQLiteDataEncoder()
+        
+        let data = try encoder.encode(emptyArray)
+    
+        let decoder = SQLiteDataDecoder()
+        
+        let result = try decoder.decode([String].self, from: data)
+        XCTAssertEqual(result, emptyArray, "Should convert back to empty Array")
+    }
 
     static let allTests = [
         ("testBenchmark", testBenchmark),


### PR DESCRIPTION
Hi! 

I recently stubble upon a crash when creating a SQLite schema model with an Array type member like so:

```swift
struct MyModel: SQLiteModel {
    var id: Int?
    var values: [String]
}
```

if I submit a JSON with an empty array, I got a crash back [here](https://github.com/vapor/sqlite/blob/500748e7bd9d19b9beeba5b4bccbe751741eb280/Sources/SQLite/Codable/SQLiteDataEncoder.swift#L27). 
So I update my Fluent* libs to the last rc4 version and investigate for this bug. 

The reason of the crash is that when the `_UnkeyedEncodingContainer` get an empty array, none of its methods get called and as a consequence, no data is returned to the encoder and it doesn't throw any `_DoJSONError()` either.

I'm not sure this is the right way to fix this, but after adding some test to check the encoding/decoding of an empty and non empty array, I've added a `guard let` statement  on the `encoder.data` value and throw the `_DoJSONError` in case it's `nil`
But maybe it would be better to move the fix directly inside the `_UnkeyedEncodingContainer` to be sure we are dealing with an array but I didn't find a clean solution at this location. 

To reproduce the bug from a real vapor project, run this sample project:

[bugEmptyArray.zip](https://github.com/vapor/sqlite/files/2136362/bugEmptyArray.zip)

Then run this cUrl command:

```sh
curl -X "POST" "http://localhost:8080/todos" \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "titles": []
}'
```

And you should got the crash with the last SQLite release.

Hope it will help! 

Have a great day!