### PR TITLE
Make each `SQLiteConnection` have its own SQLite handle

### DIFF
--- a/Sources/SQLite/Database/SQLiteConnection.swift
+++ b/Sources/SQLite/Database/SQLiteConnection.swift
@@ -87,7 +87,7 @@ public final class SQLiteConnection: BasicWorker, DatabaseConnection, DatabaseQu
         // log before anything happens, in case there's an error
         logger?.record(query: sql, values: data.map { $0.description })
         let promise = eventLoop.newPromise(Void.self)
-        database.queue.async {
+        database.blockingIO.submit { _ in
             do {
                 let statement = try SQLiteStatement(query: sql, on: self)
                 try statement.bind(data)

--- a/Sources/SQLite/Database/SQLiteConnection.swift
+++ b/Sources/SQLite/Database/SQLiteConnection.swift
@@ -112,11 +112,14 @@ public final class SQLiteConnection: BasicWorker, DatabaseConnection, DatabaseQu
     
     /// See `DatabaseConnection`.
     public func close() {
+        sqlite3_close(handle)
         isClosed = true
     }
     
     /// Closes the open SQLite handle on deinit.
     deinit {
-        sqlite3_close(handle)
+        if !isClosed {
+            close()
+        }
     }
 }

--- a/Sources/SQLite/Database/SQLiteConnection.swift
+++ b/Sources/SQLite/Database/SQLiteConnection.swift
@@ -37,7 +37,7 @@ public final class SQLiteConnection: BasicWorker, DatabaseConnection, DatabaseQu
     /// This reference will ensure the DB stays alive since this connection uses
     /// it's thread pool.
     private let database: SQLiteDatabase
-    
+
     /// Internal SQLite database handle.
     internal var handle: OpaquePointer!
 
@@ -84,7 +84,7 @@ public final class SQLiteConnection: BasicWorker, DatabaseConnection, DatabaseQu
 
         // log before anything happens, in case there's an error
         logger?.record(query: sql, values: data.map(String.init(describing:)))
-        
+
         let promise = eventLoop.newPromise(Void.self)
         database.blockingIO.submit { _ in
             do {

--- a/Sources/SQLite/Database/SQLiteConnection.swift
+++ b/Sources/SQLite/Database/SQLiteConnection.swift
@@ -39,7 +39,7 @@ public final class SQLiteConnection: BasicWorker, DatabaseConnection, DatabaseQu
     private let database: SQLiteDatabase
 
     /// Internal SQLite database handle.
-    internal var handle: OpaquePointer!
+    internal private(set) var handle: OpaquePointer!
 
     /// See `BasicWorker`.
     public let eventLoop: EventLoop

--- a/Sources/SQLite/Database/SQLiteConnection.swift
+++ b/Sources/SQLite/Database/SQLiteConnection.swift
@@ -59,7 +59,11 @@ public final class SQLiteConnection: BasicWorker, DatabaseConnection, DatabaseQu
     
     /// Returns the last error message, if one exists.
     internal var errorMessage: String? {
-        return sqlite3_errmsg(handle).map(String.init(cString:))
+        if let raw = sqlite3_errmsg(handle) {
+            return String(cString: raw)
+        } else {
+            return nil
+        }
     }
     
     /// See `SQLConnection`.

--- a/Sources/SQLite/Database/SQLiteDatabase.swift
+++ b/Sources/SQLite/Database/SQLiteDatabase.swift
@@ -39,7 +39,7 @@ public final class SQLiteDatabase: Database, LogSupporting {
             self.handle = try openConnection()
         }
     }
-    
+
     // Make database connection
     internal func openConnection() throws -> OpaquePointer {
         let path: String

--- a/Sources/SQLite/Database/SQLiteDatabase.swift
+++ b/Sources/SQLite/Database/SQLiteDatabase.swift
@@ -17,8 +17,8 @@ public final class SQLiteDatabase: Database, LogSupporting {
     /// SQLite storage method. See `SQLiteStorage`.
     public let storage: SQLiteStorage
     
-    /// Dispatch queue for performing blocking IO work. See `DispatchQueue`.
-    internal let queue: DispatchQueue
+    /// Thread pool for performing blocking IO work. See `BlockingIOThreadPool`.
+    internal let blockingIO: BlockingIOThreadPool
     
     /// Create a new SQLite database.
     ///
@@ -28,9 +28,9 @@ public final class SQLiteDatabase: Database, LogSupporting {
     ///     - storage: SQLite storage method. See `SQLiteStorage`.
     ///     - queue: Dispatch queue for performing blocking IO work. See `DispatchQueue`.
     /// - throws: Errors creating the SQLite database.
-    public init(storage: SQLiteStorage = .memory, queue: DispatchQueue = DispatchQueue(label: "SQLite Database Queue", attributes: .concurrent)) throws {
+    public init(storage: SQLiteStorage = .memory, threadPool: BlockingIOThreadPool? = nil) throws {
         self.storage = storage
-        self.queue = queue
+        self.blockingIO = threadPool ?? BlockingIOThreadPool(numberOfThreads: 2)
     }
     
     /// See `Database`.

--- a/Sources/SQLite/Database/SQLiteDatabase.swift
+++ b/Sources/SQLite/Database/SQLiteDatabase.swift
@@ -23,7 +23,7 @@ public final class SQLiteDatabase: Database, LogSupporting {
     /// If the database uses in-memory storage, this property will be set to
     /// keep the database alive when there is no `SQLiteConnection` to it.
     private var handle: OpaquePointer?
-    
+
     /// Create a new SQLite database.
     ///
     ///     let sqliteDB = SQLiteDatabase(storage: .memory)
@@ -58,7 +58,7 @@ public final class SQLiteDatabase: Database, LogSupporting {
         }
         return c
     }
-    
+
     /// See `Database`.
     public func newConnection(on worker: Worker) -> Future<SQLiteConnection> {
         do {
@@ -68,7 +68,7 @@ public final class SQLiteDatabase: Database, LogSupporting {
             return worker.future(error: error)
         }
     }
-    
+
     /// See `LogSupporting`.
     public static func enableLogging(_ logger: DatabaseLogger, on conn: SQLiteConnection) {
         conn.logger = logger

--- a/Sources/SQLite/Database/SQLiteDatabase.swift
+++ b/Sources/SQLite/Database/SQLiteDatabase.swift
@@ -26,7 +26,7 @@ public final class SQLiteDatabase: Database, LogSupporting {
     ///
     /// - parameters:
     ///     - storage: SQLite storage method. See `SQLiteStorage`.
-    ///     - queue: Dispatch queue for performing blocking IO work. See `DispatchQueue`.
+    ///     - threadPool: Thread pool for performing blocking IO work. See `BlockingIOThreadPool`.
     /// - throws: Errors creating the SQLite database.
     public init(storage: SQLiteStorage = .memory, threadPool: BlockingIOThreadPool? = nil) throws {
         self.storage = storage

--- a/Sources/SQLite/Database/SQLiteStatement.swift
+++ b/Sources/SQLite/Database/SQLiteStatement.swift
@@ -7,7 +7,7 @@ import SQLite3
 internal struct SQLiteStatement {
     private let c: OpaquePointer
     private let connection: SQLiteConnection
-    
+
     internal init(query: String, on connection: SQLiteConnection) throws {
         var handle: OpaquePointer?
         let ret = sqlite3_prepare_v2(connection.handle, query, -1, &handle, nil)
@@ -53,19 +53,19 @@ internal struct SQLiteStatement {
             }
         }
     }
-    
+
     internal func getColumns() throws -> [SQLiteColumn]? {
         var columns: [SQLiteColumn] = []
-        
+
         let count = sqlite3_column_count(c)
         columns.reserveCapacity(Int(count))
-        
+
         // iterate over column count and intialize columns once
         // we will then re-use the columns for each row
         for i in 0..<count {
             try columns.append(column(at: i))
         }
-        
+
         return columns
     }
     

--- a/Sources/SQLite/Database/SQLiteStatement.swift
+++ b/Sources/SQLite/Database/SQLiteStatement.swift
@@ -52,7 +52,6 @@ internal struct SQLiteStatement {
                 }
             }
         }
-        
     }
     
     internal func getColumns() throws -> [SQLiteColumn]? {
@@ -86,14 +85,12 @@ internal struct SQLiteStatement {
         default: throw SQLiteError(statusCode: step, connection: connection, source: .capture())
         }
         
-        
         var row: [SQLiteColumn: SQLiteData] = [:]
         
         // iterator over column count again and create a field
         // for each column. Use the column we have already initialized.
-        for i in 0..<Int32(columns.count) {
-            let col = columns[Int(i)]
-            row[col] = try data(at: i)
+        for (i, col) in columns.enumerated() {
+            row[col] = try data(at: Int32(i))
         }
         
         // return to event loop

--- a/Sources/SQLite/Database/SQLiteStorage.swift
+++ b/Sources/SQLite/Database/SQLiteStorage.swift
@@ -6,11 +6,4 @@ public enum SQLiteStorage {
     
     /// File-based storage, persisted between application launches.
     case file(path: String)
-
-    internal var path: String {
-        switch self {
-        case .memory: return ":memory:"
-        case .file(let path): return path
-        }
-    }
 }


### PR DESCRIPTION
Currently all `SQLiteConnection`s share a single underlying SQLite connection stored in an `SQLiteDatabase` object. This can cause database queries from different threads to be serialised and mixed together, resulting in potential data corruption.

This PR makes each `SQLiteConnection` have its own SQLite connection handle so that queries from different threads are run on different SQLite connections.