### PR TITLE
Use structured logging (metadata) when logging queries

### DIFF
--- a/Sources/SQLiteKit/SQLiteConnection+SQLKit.swift
+++ b/Sources/SQLiteKit/SQLiteConnection+SQLKit.swift
@@ -218,7 +218,7 @@ struct SQLiteDatabaseVersion: SQLDatabaseReportedVersion {
         let (sql, rawBinds) = self.serialize(query)
         
         if let queryLogLevel = self.queryLogLevel {
-            self.logger.log(level: queryLogLevel, "\(sql) \(rawBinds)")
+            self.logger.log(level: queryLogLevel, "Executing query", metadata: ["sql": .string(sql), "binds": .array(rawBinds.map { .string("\($0)") })])
         }
 
         let binds: [SQLiteData]
@@ -244,7 +244,7 @@ struct SQLiteDatabaseVersion: SQLDatabaseReportedVersion {
         let (sql, rawBinds) = self.serialize(query)
         
         if let queryLogLevel = self.queryLogLevel {
-            self.logger.log(level: queryLogLevel, "\(sql) \(rawBinds)")
+            self.logger.log(level: queryLogLevel, "Executing query", metadata: ["sql": .string(sql), "binds": .array(rawBinds.map { .string("\($0)") })])
         }
 
         try await self.database.query(

--- a/Sources/SQLiteKit/SQLiteConnection+SQLKit.swift
+++ b/Sources/SQLiteKit/SQLiteConnection+SQLKit.swift
@@ -218,7 +218,7 @@ struct SQLiteDatabaseVersion: SQLDatabaseReportedVersion {
         let (sql, rawBinds) = self.serialize(query)
         
         if let queryLogLevel = self.queryLogLevel {
-            self.logger.log(level: queryLogLevel, "\(sql) [\(rawBinds)]")
+            self.logger.log(level: queryLogLevel, "\(sql) \(rawBinds)")
         }
 
         let binds: [SQLiteData]
@@ -244,7 +244,7 @@ struct SQLiteDatabaseVersion: SQLDatabaseReportedVersion {
         let (sql, rawBinds) = self.serialize(query)
         
         if let queryLogLevel = self.queryLogLevel {
-            self.logger.log(level: queryLogLevel, "\(sql) [\(rawBinds)]")
+            self.logger.log(level: queryLogLevel, "\(sql) \(rawBinds)")
         }
 
         try await self.database.query(

--- a/Sources/SQLiteKit/SQLiteConnectionSource.swift
+++ b/Sources/SQLiteKit/SQLiteConnectionSource.swift
@@ -49,8 +49,7 @@ public struct SQLiteConnectionSource: ConnectionPoolSource, Sendable {
             on: eventLoop
         ).flatMap { conn in
             if self.configuration.enableForeignKeys {
-                return conn.query("PRAGMA foreign_keys = ON")
-                    .map { _ in conn }
+                return conn.query("PRAGMA foreign_keys = ON").map { _ in conn }
             } else {
                 return eventLoop.makeSucceededFuture(conn)
             }


### PR DESCRIPTION
**These changes are now available in [4.5.2](https://github.com/vapor/sqlite-kit/releases/tag/4.5.2)**


When a query is executed, the actual SQL query and its accompanying array of bound parameters (if any) are now logged as structured metadata on the logger using a generic message, rather than the query and bindings being the message. This follows the [recommended guidelines for logging in libraries](https://www.swift.org/documentation/server/guides/libraries/log-levels.html). Credit goes to @MahdiBM for the original suggestion.

Before:
```
2024-05-29T00:00:00Z debug codes.vapor.fluent : database-id=sqlite [SQLiteKit] SELECT * FROM foo WHERE a=?1 [["bar"]]
```
After:
```
2024-05-29T00:00:00Z debug codes.vapor.fluent : database-id=sqlite sql=SELECT * FROM foo WHERE a=?1 binds=["bar"] [SQLiteKit] Executing query
```
