### PR TITLE
feat: Add support for wasm compilation when using an in-memory sqlite database configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
   unit-tests:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
     secrets: inherit
+    with:
+      with_wasm: true
 
   # Make sure downstream dependents still work
   dependents-check:

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,16 +13,24 @@ let package = Package(
         .library(name: "SQLiteKit", targets: ["SQLiteKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
-        .package(url: "https://github.com/vapor/sqlite-nio.git", from: "1.9.0"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.3"),
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
+        // TODO: SM: Update swift-nio version once NIOAsyncRuntime is available from swift-nio
+        // .package(url: "https://github.com/apple/swift-nio.git", from: "2.89.0"),
+        .package(url: "https://github.com/PassiveLogic/swift-nio.git", branch: "feat/addNIOAsyncRuntimeForWasm"),
+
+        // TODO: SM: Update below once everything is merged and release to the proper repositories
+//        .package(url: "https://github.com/vapor/sqlite-nio.git", from: "1.9.0"),
+        .package(url: "https://github.com/PassiveLogic/sqlite-nio.git", branch: "feat/swift-wasm-support-v2"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.33.1"),
+//        .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
+        .package(url: "https://github.com/PassiveLogic/async-kit.git", branch: "feat/swift-wasm-support-v2"),
     ],
     targets: [
         .target(
             name: "SQLiteKit",
             dependencies: [
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOAsyncRuntime", package: "swift-nio", condition: .when(platforms: [.wasi])),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "AsyncKit", package: "async-kit"),
                 .product(name: "SQLiteNIO", package: "sqlite-nio"),
                 .product(name: "SQLKit", package: "sql-kit"),

--- a/Sources/SQLiteKit/SQLiteConnectionSource.swift
+++ b/Sources/SQLiteKit/SQLiteConnectionSource.swift
@@ -5,6 +5,10 @@ import Foundation
 #endif
 import Logging
 import AsyncKit
+#if canImport(NIOAsyncRuntime)
+import NIOAsyncRuntime
+public typealias NIOThreadPool = AsyncThreadPool
+#endif
 import NIOPosix
 import SQLiteNIO
 import NIOCore
@@ -16,7 +20,13 @@ public struct SQLiteConnectionSource: ConnectionPoolSource, Sendable {
     private let threadPool: NIOThreadPool
 
     private var connectionStorage: SQLiteConnection.Storage {
+        #if os(WASI)
+        // NOTE: For WASI platforms, file urls and paths cause runtime errors currently. Using
+        // in-memory connection only as a workaround.
+        .memory
+        #else
         .file(path: self.actualURL.absoluteString)
+        #endif
     }
     
     /// Create a new ``SQLiteConnectionSource``.

--- a/Tests/SQLiteKitTests/SQLiteKitTests.swift
+++ b/Tests/SQLiteKitTests/SQLiteKitTests.swift
@@ -105,10 +105,11 @@ final class SQLiteKitTests: XCTestCase {
         )
 
         let conn2 = try await source.makeConnection(logger: self.connection.logger, on: MultiThreadedEventLoopGroup.singleton.any()).get()
-        defer { try! conn2.close().wait() }
         
         let res2 = try await conn2.query("PRAGMA foreign_keys").get()
         XCTAssertEqual(res2[0].column("foreign_keys"), .integer(0))
+
+        try! await conn2.close().get()
     }
 
     func testJSONStringColumn() async throws {
@@ -134,18 +135,19 @@ final class SQLiteKitTests: XCTestCase {
         )
 
         let a1 = try await a.makeConnection(logger: .init(label: "test"), on: MultiThreadedEventLoopGroup.singleton.any()).get()
-        defer { try! a1.close().wait() }
         let a2 = try await a.makeConnection(logger: .init(label: "test"), on: MultiThreadedEventLoopGroup.singleton.any()).get()
-        defer { try! a2.close().wait() }
         let b1 = try await b.makeConnection(logger: .init(label: "test"), on: MultiThreadedEventLoopGroup.singleton.any()).get()
-        defer { try! b1.close().wait() }
         let b2 = try await b.makeConnection(logger: .init(label: "test"), on: MultiThreadedEventLoopGroup.singleton.any()).get()
-        defer { try! b2.close().wait() }
 
         _ = try await a1.query("CREATE TABLE foo (bar INTEGER)").get()
         _ = try await a2.query("SELECT * FROM foo").get()
         _ = try await b1.query("CREATE TABLE foo (bar INTEGER)").get()
         _ = try await b2.query("SELECT * FROM foo").get()
+
+        try! await b2.close().get()
+        try! await b1.close().get()
+        try! await a2.close().get()
+        try! await a1.close().get()
     }
 
     // https://github.com/vapor/sqlite-kit/issues/56

--- a/Tests/SQLiteKitTests/SQLiteKitTests.swift
+++ b/Tests/SQLiteKitTests/SQLiteKitTests.swift
@@ -124,6 +124,11 @@ final class SQLiteKitTests: XCTestCase {
         XCTAssertEqual(bar.baz, "qux")
     }
 
+    // NOTE: The following test doesn't work in a runtime environment
+    // due to reliance on temp files. The test is elided for now
+    // for WASI targets, but could be used in the future once
+    // a persistence solution is working for WASI platforms.
+    #if !os(WASI)
     func testMultipleInMemoryDatabases() async throws {
         let a = SQLiteConnectionSource(
             configuration: .init(storage: .memory, enableForeignKeys: true),
@@ -149,6 +154,7 @@ final class SQLiteKitTests: XCTestCase {
         try! await a2.close().get()
         try! await a1.close().get()
     }
+    #endif  // !os(WASI)
 
     // https://github.com/vapor/sqlite-kit/issues/56
     func testDoubleConstraintError() async throws {


### PR DESCRIPTION
# Summary

This PR adds support for compiling sqlite-kit to wasm using the [Swift SDK for WebAssembly](https://www.swift.org/documentation/articles/wasm-getting-started.html).

This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by a company called PassiveLogic to enable broad support for Swift WebAssembly.

# Details

- Enables WASM compilation
- Adds configuration to compile WASM in CI
- Introduces conditional dependency on [NIOAsyncRuntime](https://github.com/PassiveLogic/nio-async-runtime) for WASI platforms only, to work around the NIOPosix dependency (which does not compile to wasm).
- Conditionalizes the usage of NIOPosix using `canImport`
- Update swift-nio dependency to a version that supports the WASI platform.

# Testing done

- [x] Verified unit tests still pass
- [x] Verified no new warnings are created
- [x] Verified `swift build --swift-sdk swift-6.3-DEVELOPMENT-SNAPSHOT-2025-12-07-a_wasm --target SQL` completes without errors. This is the latest daily snapshot of the swift toolchain.
- [x] Verified a third-party executable can build this library as part of a larger wasm executable, and run sqlite in the browser.
- [x] Verified these changes compile in CI. The exception is a dependency check, which can't be completed until dependent PR's in async-kit and sqlite-nio are merged. See https://github.com/PassiveLogic/sqlite-kit/actions/runs/20180692292/job/57940103176?pr=1

# Usage notes

The current Swift 6.2.x breaks certain wasm executors that make testing wasm executables like this impossible. To fully test this running in the browser, recommend using Swift 6.3.x or later.

# Impact Risk

No known impact risk

# PR Dependencies

The following PR's must be merged and released before this PR can be reviewed and merged. It will remain in draft state until then.

https://github.com/vapor/sqlite-nio/pull/98
https://github.com/vapor/async-kit/pull/111